### PR TITLE
Catch uncaught homozygous no-calls

### DIFF
--- a/cgivar2gvcf/__init__.py
+++ b/cgivar2gvcf/__init__.py
@@ -390,8 +390,10 @@ def process_next_position(data, cgi_input, header, reference, var_only):
         #   Cambridge Reference Sequence for the mitochondrion (NC_012920.1).
         #   This assembly (though with an alternate mitochondrial sequence) is
         #   also known as UCSC hg19.
-        return [vcf_line(input_data=l, reference=reference) for l in out if
-                l['chrom'] != 'chrM']
+        vcf_lines = [vcf_line(input_data=l, reference=reference) for l in out
+                     if l['chrom'] != 'chrM']
+        return [vl for vl in vcf_lines if not
+               (var_only and vl.rstrip().endswith('./.'))]
 
 
 def convert(cgi_input, twobit_ref, twobit_name, var_only=False):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ here = path.abspath(path.dirname(__file__))
 
 setup(
     name='cgivar2gvcf',
-    version='0.1.7',
+    version='0.1.8',
     description='Conversion of Complete Genomics var file to gVCF',
     url='https://github.com/madprime/cgivar2gvcf',
     author='Mad Price Ball',


### PR DESCRIPTION
The algorithm is imperfect and falls back into making "no-calls";
this results in some complex var file regions being processed in the
var_only=True condition but becoming a homozygous no-call, creating
erroneous output that violates the "variant only" expectation.