### PR TITLE
VAF/EAF scores 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,24 +33,26 @@ An example command for a variant-only VCF file (not gVCF):
 
 Writes the new VCF file to the specified output destination.
 
-`convert_to_file(cgi_input, output_file, twobit_ref, twobit_name, var_only=False)`
+`convert_to_file(cgi_input, output_file, twobit_ref, twobit_name, var_only=False, qual_scores=False)`
 
 * **cgi_input** - Inputed Complete Genomics var file. Can be a file-like object (i.e. already open) or a path to a file (uncompressed, gzip, or bzip2 compressed).
 * **output_file** - Where to put the result. A "gz" suffix results in gzip compression, a "bz2" suffix results in bzip2 compression.
 * **twobit_ref** - Path to the UCSC twobit reference genome file
 * **twobit_name** - name of the twobit reference file (so we can cite this in the VCF header as the "reference")
 * **var_only** - (optional) default false. Set to true if you only want variant lines.
+* **qual_scores** - (optional) default false. Set to true if you only want complete genomics VAF and EAF scores to be included in the output.
 
 ### convert
 
 Returns a generator object that yields lines of the VCF file.
 
-`convert(cgi_input, twobit_ref, twobit_name, var_only=False)`
+`convert(cgi_input, twobit_ref, twobit_name, var_only=False, qual_scores=False)`
 
 * **cgi_input** - Inputed Complete Genomics var file. Can be a file-like object (i.e. already open) or a path to a file (uncompressed, gzip, or bzip2 compressed).
 * **twobit_ref** - Path to the UCSC twobit reference genome file
 * **twobit_name** - name of the twobit reference file (so we can cite this in the VCF header as the "reference")
 * **var_only** - (optional) default false. Set to true if you only want variant lines.
+* **qual_scores** - (optional) default false. Set to true if you only want complete genomics VAF and EAF scores to be included in the output.
 
 ### get_reference_genome_file
 

--- a/cgivar2gvcf/__init__.py
+++ b/cgivar2gvcf/__init__.py
@@ -448,13 +448,14 @@ def convert(cgi_input, twobit_ref, twobit_name, var_only=False):
                 yield line
 
 
-def convert_to_file(cgi_input, output_file, twobit_ref, twobit_name, var_only=False):
+def convert_to_file(cgi_input, output_file, twobit_ref, twobit_name, var_only=False, qual_scores=False):
     """Convert a CGI var file and output VCF-formatted data to file"""
 
     if isinstance(output_file, str):
         output_file = auto_zip_open(output_file, 'w')
 
-    conversion = convert(cgi_input=cgi_input, twobit_ref=twobit_ref, twobit_name=twobit_name, var_only=var_only)
+    conversion = convert(cgi_input=cgi_input, twobit_ref=twobit_ref, twobit_name=twobit_name, var_only=var_only,
+                         qual_scores=qual_scores)
     for line in conversion:
         output_file.write(line + "\n")
     output_file.close()

--- a/cgivar2gvcf/__init__.py
+++ b/cgivar2gvcf/__init__.py
@@ -65,7 +65,7 @@ def formatted_vcf_line(vcf_data):
     return '\t'.join([vcf_data[k] for k in vcf_data])
 
 
-def process_full_position(data, header, var_only=False):
+def process_full_position(data, header, var_only=False, qual_scores=False):
     """
     Return genetic data when all alleles called on same line.
 
@@ -100,10 +100,6 @@ def process_full_position(data, header, var_only=False):
     alleles = [data[header['alleleSeq']]]
     dbsnp_data = []
     dbsnp_data = data[header['xRef']].split(';')
-    var_scores = []
-    if data[header['varScoreVAF']] or data[header['varScoreEAF']]:
-        var_scores.append(data[header['varScoreVAF']])
-        var_scores.append(data[header['varScoreEAF']])
     assert data[header['ploidy']] in ['1', '2']
     if feature_type == 'ref' or feature_type == 'no-call':
         return [{'chrom': chrom,
@@ -115,6 +111,11 @@ def process_full_position(data, header, var_only=False):
                  'filters': filters,
                  'end': data[header['end']]}]
     else:
+        var_scores = []
+        assert data[header['varScoreVAF']] and data[header['varScoreEAF']]
+        if qual_scores:
+            var_scores.append(data[header['varScoreVAF']])
+            var_scores.append(data[header['varScoreEAF']])
         return [{'chrom': chrom,
                  'start': start,
                  'dbsnp_data': dbsnp_data,

--- a/cgivar2gvcf/__init__.py
+++ b/cgivar2gvcf/__init__.py
@@ -504,6 +504,9 @@ def from_command_line():
     parser.add_argument(
         '-v', '--var-only', action='store_true', dest='varonly',
         help='Only report variant lines (i.e. VCF, but not gVCF)')
+    parser.add_argument(
+        '-q', '--qual-scores', action='store_true', dest='qualscores',
+        help='Include VAF and EAF variant quality scores in the output')
     args = parser.parse_args()
 
     # Get local twobit file from its directory. Download and store if needed.
@@ -520,13 +523,15 @@ def from_command_line():
                         args.vcfoutfile,
                         twobit_path,
                         twobit_name,
-                        args.varonly)
+                        args.varonly,
+                        args.qualscores)
     else:
         for line in convert(
                 cgi_input=var_input,
                 twobit_ref=twobit_path,
                 twobit_name=twobit_name,
-                var_only=args.varonly):
+                var_only=args.varonly,
+                qual_scores=args.qualscores):
             print(line)
 
 

--- a/cgivar2gvcf/__init__.py
+++ b/cgivar2gvcf/__init__.py
@@ -360,7 +360,7 @@ def vcf_line(input_data, reference):
     return formatted_vcf_line(vcf_data)
 
 
-def process_next_position(data, cgi_input, header, reference, var_only):
+def process_next_position(data, cgi_input, header, reference, var_only, qual_scores):
     """
     Determine appropriate processing to get data, then convert it to VCF
 
@@ -382,13 +382,14 @@ def process_next_position(data, cgi_input, header, reference, var_only):
     if data[2] == "all" or data[1] == "1":
         # The output from process_full_position is an array, so it can be
         # treated in the same manner as process_split_position output.
-        out = process_full_position(data=data, header=header, var_only=var_only)
+        out = process_full_position(data=data, header=header, var_only=var_only, qual_scores=qual_scores)
     else:
         assert data[2] == "1"
         # The output from process_split_position is a generator, and may end
         # up calling itself recursively.
         out = process_split_position(
-            data=data, cgi_input=cgi_input, header=header, reference=reference, var_only=var_only)
+            data=data, cgi_input=cgi_input, header=header, reference=reference, var_only=var_only,
+            qual_scores=qual_scores)
     if out:
 
         # ChrM is skipped because Complete Genomics is using a different

--- a/cgivar2gvcf/__init__.py
+++ b/cgivar2gvcf/__init__.py
@@ -404,7 +404,7 @@ def process_next_position(data, cgi_input, header, reference, var_only):
                (var_only and vl.rstrip().endswith('./.'))]
 
 
-def convert(cgi_input, twobit_ref, twobit_name, var_only=False):
+def convert(cgi_input, twobit_ref, twobit_name, var_only=False, qual_scores=False):
     """Generator that converts CGI var data to VCF-formated strings"""
 
     # Set up CGI input. Default is to assume a str generator.
@@ -440,7 +440,7 @@ def convert(cgi_input, twobit_ref, twobit_name, var_only=False):
 
         out = process_next_position(
             data=data, cgi_input=cgi_input, header=header, reference=reference,
-            var_only=var_only)
+            var_only=var_only, qual_scores=qual_scores)
 
         # process_next_position returns an array of one or more lines
         if out:

--- a/cgivar2gvcf/__init__.py
+++ b/cgivar2gvcf/__init__.py
@@ -34,13 +34,16 @@ FILEDATE = datetime.datetime.now()
 def make_header(reference):
     header = """##fileformat=VCFv4.1
 ##fileDate={}{}{}
-##source=cgivar2gvcf-version-0.1.6
+##source=cgivar2gvcf-version-0.1.9
 ##description="Produced from a Complete Genomics var file using cgivar2gvcf. Not intended for clinical use."
 ##reference={}
+##FILTER=<ID=PASS,Description="All filters passed">
 ##FILTER=<ID=NOCALL,Description="Some or all of this record had no sequence call by Complete Genomics">
 ##FILTER=<ID=VQLOW,Description="Some or all of this sequence call marked as low variant quality by Complete Genomics">
 ##FILTER=<ID=AMBIGUOUS,Description="Some or all of this sequence call marked as ambiguous by Complete Genomics">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=VAF,Number=R,Type=Integer,Description="Positive integer representing confidence in the call as reported in the varScoreVAF of Complete Genomics. It is derived from the probability estimates under maximum likelihood variable allele fraction. This field is empty for reference calls or no-calls">
+##FORMAT=<ID=EAF,Number=R,Type=Integer,Description="Positive or negative integer representing confidence in the call as reported in the varScoreEAF of Complete Genomics. It is derived from the probability estimates under equal allele fraction model. This field is empty for reference calls or no-calls">
 ##INFO=<ID=END,Number=1,Type=Integer,Description="Stop position of the interval">
 """.format(FILEDATE.year, FILEDATE.month, FILEDATE.day, reference)
     header = header + ("#" + '\t'.join([k for k in VCF_DATA_TEMPLATE]))

--- a/cgivar2gvcf/__init__.py
+++ b/cgivar2gvcf/__init__.py
@@ -100,6 +100,10 @@ def process_full_position(data, header, var_only=False):
     alleles = [data[header['alleleSeq']]]
     dbsnp_data = []
     dbsnp_data = data[header['xRef']].split(';')
+    var_scores = []
+    if data[header['varScoreVAF']] or data[header['varScoreEAF']]:
+        var_scores.append(data[header['varScoreVAF']])
+        var_scores.append(data[header['varScoreEAF']])
     assert data[header['ploidy']] in ['1', '2']
     if feature_type == 'ref' or feature_type == 'no-call':
         return [{'chrom': chrom,
@@ -117,6 +121,7 @@ def process_full_position(data, header, var_only=False):
                  'ref_seq': ref_allele,
                  'alleles': alleles,
                  'allele_count': data[header['ploidy']],
+                 'varScores': var_scores,
                  'filters': filters}]
 
 

--- a/cgivar2gvcf/__init__.py
+++ b/cgivar2gvcf/__init__.py
@@ -122,7 +122,7 @@ def process_full_position(data, header, var_only=False, qual_scores=False):
                  'ref_seq': ref_allele,
                  'alleles': alleles,
                  'allele_count': data[header['ploidy']],
-                 'varScores': var_scores,
+                 'var_scores': var_scores,
                  'filters': filters}]
 
 
@@ -243,7 +243,7 @@ def process_split_position(data, cgi_input, header, reference, var_only=False, q
                    'dbsnp_data': dbsnp_data,
                    'ref_seq': ref_seq,
                    'alleles': [a1_seq, a2_seq],
-                   'varScores': [a1_vaf_score, a1_eaf_score, a2_vaf_score, a2_eaf_score],
+                   'var_scores': [a1_vaf_score + ',' + a2_vaf_score, a1_eaf_score + ',' + a2_eaf_score],
                    'allele_count': '2',
                    'filters': list(set(a1_filters + a2_filters))}
         else:
@@ -255,7 +255,7 @@ def process_split_position(data, cgi_input, header, reference, var_only=False, q
                     'dbsnp_data': [],
                     'ref_seq': '=',
                     'alleles': ['?'],
-                    #'varScores': [a1_vaf_score, a1_eaf_score, a2_vaf_score, a2_eaf_score],
+                    #'var_scores': [a1_vaf_score, a1_eaf_score, a2_vaf_score, a2_eaf_score],
                     'allele_count': '2',
                     'filters': ['NOCALL'],
                     'end': end}
@@ -366,8 +366,12 @@ def vcf_line(input_data, reference):
     vcf_data['ID'] = id_field
     vcf_data['REF'] = ref_allele
     vcf_data['ALT'] = ','.join(alt_alleles) if alt_alleles else '.'
-    vcf_data['FORMAT'] = 'GT'
-    vcf_data['SAMPLE'] = genotype
+    if input_data['var_scores']:
+        vcf_data['FORMAT'] = 'GT:VAF:EAF'
+        vcf_data['SAMPLE'] = ':'.join([genotype] + input_data['var_scores'])
+    else:
+        vcf_data['FORMAT'] = 'GT'
+        vcf_data['SAMPLE'] = genotype
 
     if input_data['filters']:
         vcf_data['FILTER'] = ';'.join(sorted(input_data['filters']))

--- a/cgivar2gvcf/__init__.py
+++ b/cgivar2gvcf/__init__.py
@@ -184,7 +184,7 @@ def get_split_pos_lines(data, cgi_input, header):
     return s1_data, s2_data, next_data
 
 
-def process_split_position(data, cgi_input, header, reference, var_only=False):
+def process_split_position(data, cgi_input, header, reference, var_only=False, qual_scores=False):
     """Process CGI var where alleles are reported separately.
 
     Split positions report each allele with one or more lines. To ensure that
@@ -211,12 +211,12 @@ def process_split_position(data, cgi_input, header, reference, var_only=False):
 
     # Process all the lines to get concatenated sequences and other data.
     dbsnp_data = []
-    a1_seq, ref_seq, start, a1_filters = process_allele(
+    a1_seq, ref_seq, start, a1_filters, a1_vaf_score, a1_eaf_score = process_allele(
         allele_data=s1_data, dbsnp_data=dbsnp_data,
-        header=header, reference=reference)
-    a2_seq, r2_seq, a2_start, a2_filters = process_allele(
+        header=header, reference=reference, qual_scores=qual_scores)
+    a2_seq, r2_seq, a2_start, a2_filters, a2_vaf_score, a2_eaf_score = process_allele(
         allele_data=s2_data, dbsnp_data=dbsnp_data,
-        header=header, reference=reference)
+        header=header, reference=reference, qual_scores=qual_scores)
     # clean dbsnp data
     dbsnp_data = [x for x in dbsnp_data if x]
     if (a1_seq or ref_seq) and (a2_seq or r2_seq):
@@ -229,6 +229,7 @@ def process_split_position(data, cgi_input, header, reference, var_only=False):
                    'dbsnp_data': dbsnp_data,
                    'ref_seq': ref_seq,
                    'alleles': [a1_seq, a2_seq],
+                   'varScores': [a1_vaf_score, a1_eaf_score, a2_vaf_score, a2_eaf_score],
                    'allele_count': '2',
                    'filters': list(set(a1_filters + a2_filters))}
         else:
@@ -240,6 +241,7 @@ def process_split_position(data, cgi_input, header, reference, var_only=False):
                     'dbsnp_data': [],
                     'ref_seq': '=',
                     'alleles': ['?'],
+                    #'varScores': [a1_vaf_score, a1_eaf_score, a2_vaf_score, a2_eaf_score],
                     'allele_count': '2',
                     'filters': ['NOCALL'],
                     'end': end}
@@ -248,11 +250,11 @@ def process_split_position(data, cgi_input, header, reference, var_only=False):
     # the start of a new split position - very unlikely, though.
     if next_data[2] == "all" or next_data[1] == "1":
         out = process_full_position(
-            data=next_data, header=header, var_only=var_only)
+            data=next_data, header=header, var_only=var_only, qual_scores=qual_scores)
     else:
         out = process_split_position(
             data=next_data, cgi_input=cgi_input, header=header,
-            reference=reference, var_only=var_only)
+            reference=reference, var_only=var_only, qual_scores=qual_scores)
     if out:
         for entry in out:
             yield entry

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ here = path.abspath(path.dirname(__file__))
 
 setup(
     name='cgivar2gvcf',
-    version='0.1.8',
+    version='0.1.9',
     description='Conversion of Complete Genomics var file to gVCF',
     url='https://github.com/madprime/cgivar2gvcf',
     author='Mad Price Ball',


### PR DESCRIPTION
Complete Genomics varfiles have two columns with the quantitative scores varScoreVAF and varScoreEAF, which are given whenever a position has an alternate allele (absent in full ref calls or no-calls). 

These proposed changes simply add to the base code the optional ability to output and keep these scores into the gVCF/VCF if the user wants it.

Your base code is beautiful and elegant. I have learned many things while working with it. 
Thanks for sharing